### PR TITLE
Throw exception in case gluino mass parameter is negative

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,17 @@
+Himalaya 2.0.2
+==============
+
+Changes
+-------
+
+ * [commit 462c43c]: An exception is thrown if the (input) gluino mass
+   parameter is negative.
+
+   The implemented 2- and 3-loop contributions usually assume that
+   M3 > 0. For this reason the gluino phase factor is absent from the
+   expressions (i.e. has always been set to 1) and cannot be adjusted
+   in case M3 < 0 to make the gluino mass positive.
+
 Himalaya 2.0.1
 ==============
 

--- a/source/Himalaya_interface.cpp
+++ b/source/Himalaya_interface.cpp
@@ -115,6 +115,14 @@ void Parameters::validate(bool verbose)
          "must be greater than zero!");
    }
 
+   // The implemented 2- and 3-loop contributions assumed that M3 > 0.
+   // For this reason the gluino phase factor is absent from the
+   // expressions (i.e. has always been set to 1) and cannot be
+   // adjusted in case M3 < 0.
+   if (MG < 0.) {
+      throw std::runtime_error("Gluino mass parameter must not be negative!");
+   }
+
    // force gluino mass to be positive
    MG = std::abs(MG);
 


### PR DESCRIPTION
The implemented 2- and 3-loop contributions usually assume that M3 > 0. For this reason the gluino phase factor is absent from the expressions (i.e. has always been set to 1) and cannot be adjusted in case M3 < 0 to make the gluino mass positive.